### PR TITLE
Add vscode-spectral installation scripts to npm postinstall script

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
   "scripts": {
     "clean": "rimraf tmp/*",
     "release": "np --no-yarn",
-    "test": "echo 1"
+    "test": "echo 1",
+    "postinstall": "./script/vscode-spectral-build.sh"
   },
   "dependencies": {
     "@stoplight/spectral": "^5.8.0",

--- a/script/vscode-spectral-build.sh
+++ b/script/vscode-spectral-build.sh
@@ -18,7 +18,7 @@ git pull --rebase
 
 # npm install
 cd $DIR/../tmp/vscode-spectral
-yarn add gulp gulp-cli
+yarn config set ignore-engines true
 yarn
 yarn compile
 


### PR DESCRIPTION
Fixes #3 Fixes #2

This PR adds vscode-spectral-build.sh to postinstall scripts.

Because now node LTS version is `16.14.2` and [vscode-spectral](https://github.com/stoplightio/vscode-spectral) still needs `^12.13` I added the `ignore-engines` to yarn (I assume most people will have node > 12.13).

## Note

For people coming from nvim and trying to setup this language server with [nvim-lspconfig](https://github.com/neovim/nvim-lspconfig) i recommend [nvim-lsp-installer](https://github.com/williamboman/nvim-lsp-installer) to install new language servers.