### PR TITLE
:bug: Fix: vscode-spectral-build script

### DIFF
--- a/script/vscode-spectral-build.sh
+++ b/script/vscode-spectral-build.sh
@@ -8,7 +8,7 @@ mkdir -p $DIR/../dist
 
 # clone
 cd $DIR/../tmp
-git clone --depth=1 git@github.com:stoplightio/vscode-spectral.git vscode-spectral
+git clone --depth=1 git@github.com:stoplightio/vscode-spectral.git -b v0.2.5 vscode-spectral
 
 # pull
 cd $DIR/../tmp/vscode-spectral


### PR DESCRIPTION
> Since https://github.com/stoplightio/vscode-spectral released v1.0.0 the post install script is not working, because it does not provide the `compile` script anymore.
Thanks @filipiz

closes #1
fixes #5